### PR TITLE
Update gen_merged_model.py

### DIFF
--- a/tools/gen_merged_model.py
+++ b/tools/gen_merged_model.py
@@ -194,7 +194,7 @@ def remove_empty_layers(net, model):
 # A function to add 'engine: CAFFE' param into 1x1 convolutions
 def set_engine_caffe(layer, net, model, i):
     if layer.type == 'Convolution':
-        if layer.convolution_param.kernel_size == 1\
+        if layer.convolution_param.kernel_size[0] == 1\
             or (layer.convolution_param.kernel_h == layer.convolution_param.kernel_w == 1):
             layer.convolution_param.engine = dict(layer.convolution_param.Engine.items())['CAFFE']
 


### PR DESCRIPTION
Fix a bug for function set_engine_caffe:
  The reture value of layer.convolution_param.kernel_size is always a list containing only one element rather than a single value.